### PR TITLE
BUG - Path should have no dependency

### DIFF
--- a/bulk-move/form.php
+++ b/bulk-move/form.php
@@ -4,7 +4,7 @@ printAdminHeader('overview', gettext('Bulk move images'));
 printZenJavascripts()
 ?>
 <script src="bulk-move.js?v=22"></script>
-<script src="/plugins/admin-chosen-dropdowns/chosen.jquery.min.js"></script>
+<script src="chosen.jquery.min.js"></script>
 <link rel="stylesheet" type="text/css" media="screen" href="bulk-move.css" />
 <?php
 echo '</head>';


### PR DESCRIPTION
The path points to a directory which is not covered by the bulk-move plugin. The path relies on a different plugin (zenphoto-admin-chosen-dropdowns) which can't be found in the web (though it's mentioned on the Zenphoto website which is confusing: https://www.zenphoto.org/news/zenphoto-admin-chosen-dropdowns/). Since you provide chosen.jquery.min.js with bulk-move, there is no need to point to any depending plugin.

Thank you for your bulk-move plugin!